### PR TITLE
create integration test framework, improve integration test

### DIFF
--- a/examples/datawarehouse/Pulumi.serverless-db.integration.test.yaml
+++ b/examples/datawarehouse/Pulumi.serverless-db.integration.test.yaml
@@ -1,5 +1,0 @@
-config:
-  aws:region: us-west-2
-  pulumi-serverless-db:shards: '{"prod": 8, "gamma": 4, "beta": 1}'
-  pulumi-serverless-db:stage: beta
-  pulumi-serverless-db:dev: true

--- a/examples/datawarehouse/index.ts
+++ b/examples/datawarehouse/index.ts
@@ -1,5 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
+
 import { ServerlessDataWarehouse, StreamingInputTableArgs } from "../../lib/datawarehouse";
 import { createEventGenerator } from "./eventGenerator";
 
@@ -50,8 +51,12 @@ const dataWarehouse = new ServerlessDataWarehouse("analytics_dw", { isDev })
 const impressionsInputStream = dataWarehouse.getInputStream(impressionsTableName);
 const clicksInputStream = dataWarehouse.getInputStream(clicksTableName);
 
-export const impressionInputStream = impressionsInputStream.name;
-export const clickInputStream = clicksInputStream.name;
-
 createEventGenerator("impression", impressionsInputStream.name);
 createEventGenerator("clicks", clicksInputStream.name);
+
+export const impressionInputStream = impressionsInputStream.name;
+export const clickInputStream = clicksInputStream.name;
+export const databaseName = dataWarehouse.database.name;
+export const impressionTableName = dataWarehouse.getTable(impressionsTableName).name;
+export const clickTableName = dataWarehouse.getTable(clicksTableName).name;
+export const athenaResultsBucket = dataWarehouse.queryResultsBucket.bucket;

--- a/examples/datawarehouse/package.json
+++ b/examples/datawarehouse/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "aws-typescript",
+  "name": "serverlessdb-example",
   "devDependencies": {
     "@babel/preset-typescript": "^7.7.2",
     "@types/jest": "^24.0.23",

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  testRunner: "jest-circus/runner"
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -571,9 +571,9 @@
             "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
         },
         "@pulumi/aws": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-1.8.0.tgz",
-            "integrity": "sha512-wPEFObM0bMl9u9nRdcxH23c7wdpsDvYaUP9rg7GOkG41dnRA5tjpxaC06gyYJX2bVrp2OTgPvlvtz8qicktXjQ==",
+            "version": "1.17.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/aws/-/aws-1.17.0.tgz",
+            "integrity": "sha512-x+NQJKoeMMfwrhxtYbrmpBFMpH/dgxGky3tRYw5l7ZDVtaBVU2rdM4pXnM4FReCZHXNv5oTaQGeeWGizivazGA==",
             "requires": {
                 "@pulumi/pulumi": "^1.0.0",
                 "aws-sdk": "^2.0.0",
@@ -3082,9 +3082,9 @@
             }
         },
         "handlebars": {
-            "version": "4.5.2",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-            "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+            "version": "4.5.3",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+            "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
             "dev": true,
             "requires": {
                 "neo-async": "^2.6.0",
@@ -3670,6 +3670,30 @@
             "requires": {
                 "@jest/types": "^24.9.0",
                 "execa": "^1.0.0",
+                "throat": "^4.0.0"
+            }
+        },
+        "jest-circus": {
+            "version": "24.9.0",
+            "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-24.9.0.tgz",
+            "integrity": "sha512-dwkvwFtRc9Anmk1XTc+bonVL8rVMZ3CeGMoFWmv1oaQThdAgvfI9bwaFlZp+gLVphNVz6ZLfCWo3ERhS5CeVvA==",
+            "dev": true,
+            "requires": {
+                "@babel/traverse": "^7.1.0",
+                "@jest/environment": "^24.9.0",
+                "@jest/test-result": "^24.9.0",
+                "@jest/types": "^24.9.0",
+                "chalk": "^2.0.1",
+                "co": "^4.6.0",
+                "expect": "^24.9.0",
+                "is-generator-fn": "^2.0.0",
+                "jest-each": "^24.9.0",
+                "jest-matcher-utils": "^24.9.0",
+                "jest-message-util": "^24.9.0",
+                "jest-snapshot": "^24.9.0",
+                "jest-util": "^24.9.0",
+                "pretty-format": "^24.9.0",
+                "stack-utils": "^1.0.1",
                 "throat": "^4.0.0"
             }
         },
@@ -5974,9 +5998,9 @@
             "dev": true
         },
         "uglify-js": {
-            "version": "3.6.9",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.9.tgz",
-            "integrity": "sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==",
+            "version": "3.7.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.3.tgz",
+            "integrity": "sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==",
             "dev": true,
             "optional": true,
             "requires": {

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
     "@types/jest": "^24.0.23",
     "@types/node": "^8.0.0",
     "jest": "^24.9.0",
+    "jest-circus": "^24.9.0",
     "ts-jest": "^24.1.0",
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "@pulumi/aws": "^1.0.0",
+    "@pulumi/aws": "^1.17.0",
     "@pulumi/awsx": "^0.18.10",
     "@pulumi/pulumi": "^1.0.0",
     "@types/moment-timezone": "^0.5.12",

--- a/testing/integration/execute.ts
+++ b/testing/integration/execute.ts
@@ -1,0 +1,40 @@
+import { spawn } from 'child_process';
+
+export interface CommandResult {
+    success: boolean;
+    error?: string;
+}
+
+export const execCommand = async (cmd: string, args: string[], onStdErr?: (msg: string) => void, onStdOut?: (msg: string) => void) => {
+    console.log(`Executing command: ${cmd} ${args.join(" ")}`);
+    const proc = spawn(cmd, args);
+
+    proc.stdout.setEncoding('utf8');
+    proc.stderr.setEncoding('utf8');
+
+    const procFuture = new Promise<CommandResult>((resolve) => {
+        const err: string[] = [];
+
+        proc.stderr.on('data', (chunk) => {
+            console.error(chunk)
+            if (onStdErr) onStdErr(chunk.toString());
+            err.push(chunk.toString());
+        });
+
+        proc.stdout.on('data', (chunk) => {
+            console.log(chunk)
+            if (onStdOut) onStdOut(chunk.toString());
+        });
+
+        proc.on('close', (code) => {
+            if (code === 0) {
+                resolve({ success: true });
+            }
+            else {
+                resolve({ success: true, error: err.join('\n') });
+            }
+        });
+    });
+
+    return await procFuture;
+};

--- a/testing/integration/index.ts
+++ b/testing/integration/index.ts
@@ -1,0 +1,120 @@
+import { execCommand, CommandResult } from "./execute"
+
+export class PulumiRunner {
+
+    private stackName: string;
+    private outputs: { [key: string]: string } = {};
+    private pulumiProjDir: string;
+    private config: string[];
+
+    constructor(config: { [key: string]: string }, pulumiProjectDir: string) {
+        this.config = this.createConfigArray(config);
+        this.pulumiProjDir = pulumiProjectDir;
+
+        const randomDigits = 6;
+        const randomSuffix = (Math.random() * Math.pow(10, randomDigits)).toFixed(0);
+        this.stackName = `integration.test.${randomSuffix}`;
+    }
+
+    public async setup(): Promise<RunnerResult> {
+        try {
+            const initResult = await this.stackInit();
+            if (!initResult.success) {
+                return Promise.resolve({ success: false, error: initResult.error })
+            }
+
+            const upResult = await this.up();
+            if (!upResult.success) {
+                return Promise.resolve({ success: false, error: upResult.error })
+            }
+
+            const outputResult = await this.stackOutputs();
+            if (!outputResult.success) {
+                return Promise.resolve({ success: false, error: outputResult.error })
+            }
+            return Promise.resolve({ success: true });;
+        } catch (e) {
+            return Promise.resolve({ success: false, error: e });
+        }
+    }
+
+    public async teardown(): Promise<RunnerResult> {
+        try {
+            const destoryResult = await this.destroy();
+            if (!destoryResult.success) {
+                return Promise.resolve({ success: false, error: destoryResult.error })
+            }
+            const rmResult = await this.stackRemove();
+            if (!rmResult.success) {
+                return Promise.resolve({ success: false, error: rmResult.error })
+            }
+            return Promise.resolve({ success: true });
+        } catch (e) {
+            return Promise.resolve({ success: false, error: e });
+        }
+    }
+
+    public getStackOutput(key: string): string {
+        return this.outputs[key]
+    };
+
+    public getStackOutputKeys(): string[] {
+        return Object.keys(this.outputs);
+    }
+
+    public getStackName(): string {
+        return this.stackName;
+    }
+
+    private async stackInit(): Promise<CommandResult> {
+        return await execCommand("pulumi", ["stack", "init", this.stackName, "--cwd", this.pulumiProjDir]);
+    }
+
+    private async up(): Promise<CommandResult> {
+        return await execCommand("pulumi", ["up", "--non-interactive", "--cwd", this.pulumiProjDir, ...this.config]);
+    }
+
+    private async stackOutputs(): Promise<CommandResult> {
+        try {
+            const result: string[] = [];
+            const onStdOut = (output: string) => {
+                result.push(output);
+            };
+            const outputResult = await execCommand("pulumi", ["stack", "output", "--cwd", this.pulumiProjDir, "--json"], undefined, onStdOut);
+            if (!outputResult.success) throw new Error("Failed to get stack outputs: ${outputResult.error}");
+
+            const json = result.join();
+            const parsedOutput = JSON.parse(json);
+            for (const key of Object.keys(parsedOutput)) {
+                this.outputs[key] = parsedOutput[key];
+            }
+            return Promise.resolve({ success: true });
+        } catch (e) {
+            return Promise.resolve({ success: false, error: e });
+        }
+
+    }
+
+    private async destroy(): Promise<CommandResult> {
+        return await execCommand("pulumi", ["destroy", "--non-interactive", "--cwd", this.pulumiProjDir]);
+    }
+
+    private async stackRemove(): Promise<CommandResult> {
+        return await execCommand("pulumi", ["stack", "rm", this.stackName, "--cwd", this.pulumiProjDir, "--yes"]);
+    }
+
+    private createConfigArray(config: { [key: string]: string }): string[] {
+        const result: string[] = [];
+        for (const key of Object.keys(config)) {
+            result.push("-c");
+            result.push(`${key}=${config[key]}`);
+        }
+
+        return result
+    }
+}
+
+export interface RunnerResult {
+    success: boolean
+    error?: string
+}

--- a/testing/integration/index.ts
+++ b/testing/integration/index.ts
@@ -40,9 +40,9 @@ export class PulumiRunner {
 
     public async teardown(): Promise<RunnerResult> {
         try {
-            const destoryResult = await this.destroy();
-            if (!destoryResult.success) {
-                return Promise.resolve({ success: false, error: destoryResult.error })
+            const destroyResult = await this.destroy();
+            if (!destroyResult.success) {
+                return Promise.resolve({ success: false, error: destroyResult.error })
             }
             const rmResult = await this.stackRemove();
             if (!rmResult.success) {


### PR DESCRIPTION
I created a more robust integration test runner that attempt to handle errors a little better. I factored this out into a reusable framework under `/testing/integration`. I also added some logic to the actual integration test that issues a few queries to athena for each table that we create, and ensures that it get's some records back. 