### PR TITLE
.WithBatchInputTable() and JSON support

### DIFF
--- a/examples/datawarehouse/eventGenerator.ts
+++ b/examples/datawarehouse/eventGenerator.ts
@@ -39,7 +39,6 @@ export const createEventGenerator = (eventType: string, inputStreamName: pulumi.
         jobFn: eventGenCallback,
         scheduleExpression: "rate(1 minute)",
         policyARNsToAttach: [
-            aws.iam.ManagedPolicies.AWSLambdaFullAccess,
             aws.iam.ManagedPolicies.AmazonKinesisFullAccess
         ]
     };

--- a/examples/datawarehouse/eventGenerator.ts
+++ b/examples/datawarehouse/eventGenerator.ts
@@ -2,72 +2,47 @@ import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
 import { CallbackFunction } from "@pulumi/aws/lambda";
+import { LambdaCronJob, LambdaCronJobArgs } from "../../lib/datawarehouse/lambdaCron";
 
 // TODO create component resource for this
 export const createEventGenerator = (eventType: string, inputStreamName: pulumi.Output<string>) => {
-    let lambdaAssumeRolePolicy = {
-        "Version": "2012-10-17",
-        "Statement": [
-            {
-                "Action": "sts:AssumeRole",
-                "Principal": {
-                    "Service": "lambda.amazonaws.com",
-                },
-                "Effect": "Allow",
-                "Sid": "",
-            },
-        ],
+    const eventGenCallback = (event: EventRuleEvent) => {
+        const AWS = require("aws-sdk");
+        const uuid = require("uuid/v4")
+        const kinesis = new AWS.Kinesis();
+        const records: any = [];
+
+        const sessionId = uuid();
+        const eventId = uuid();
+        const record = {
+            Data: JSON.stringify({
+                id: eventId,
+                session_id: sessionId,
+                message: "this is a message",
+                event_type: eventType,
+            }),
+            PartitionKey: sessionId
+        };
+        records.push(record);
+
+        kinesis.putRecords({
+            Records: records,
+            StreamName: inputStreamName.get()
+        }, (err: any) => {
+            if (err) {
+                console.error(err)
+            }
+        });
     };
 
-    const eventGenRole = new aws.iam.Role(`${eventType}-eventGenLambdaRole`, {
-        assumeRolePolicy: JSON.stringify(lambdaAssumeRolePolicy),
-    });
-
-    const eventGenLambdaAccess = new aws.iam.RolePolicyAttachment(`${eventType}-event-gen-lambda-access`, {
-        role: eventGenRole,
-        policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
-    });
-
-    const eventGenKinesisAccess = new aws.iam.RolePolicyAttachment(`${eventType}-event-gen-kinesis-access`, {
-        role: eventGenRole,
-        policyArn: aws.iam.ManagedPolicies.AmazonKinesisFullAccess,
-    });
-
-
-    const eventCron = new aws.cloudwatch.EventRule(`${eventType}-event-gen-cron`, {
+    const lambdaCronArgs: LambdaCronJobArgs = {
+        jobFn: eventGenCallback,
         scheduleExpression: "rate(1 minute)",
-    });
+        policyARNsToAttach: [
+            aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+            aws.iam.ManagedPolicies.AmazonKinesisFullAccess
+        ]
+    };
 
-    eventCron.onEvent(`${eventType}-event-generator`, new CallbackFunction(`${eventType}-event-gen-callback`, {
-        role: eventGenRole,
-        callback: (event: EventRuleEvent) => {
-            const AWS = require("aws-sdk");
-            const uuid = require("uuid/v4")
-            const kinesis = new AWS.Kinesis();
-            const records: any = [];
-
-            const sessionId = uuid();
-            const eventId = uuid();
-            const record = {
-                Data: JSON.stringify({
-                    id: eventId,
-                    session_id: sessionId,
-                    message: "this is a message",
-                    event_type: eventType,
-                }),
-                PartitionKey: sessionId
-            };
-            records.push(record);
-
-            kinesis.putRecords({
-                Records: records,
-                StreamName: inputStreamName.get()
-            }, (err: any) => {
-                if (err) {
-                    console.error(err)
-                }
-            });
-        }
-
-    }));
+    new LambdaCronJob(`${eventType}-eventGenerator`, lambdaCronArgs);
 };

--- a/examples/datawarehouse/index.ts
+++ b/examples/datawarehouse/index.ts
@@ -50,7 +50,7 @@ const genericTableArgs: StreamingInputTableArgs = {
 }
 
 // create two tables with kinesis input streams, writing data into hourly partitions in S3. 
-const dataWarehouse = new ServerlessDataWarehouse("analytics_dw_integration", { isDev })
+const dataWarehouse = new ServerlessDataWarehouse("analytics_dw", { isDev })
     .withStreamingInputTable(impressionsTableName, genericTableArgs)
     .withStreamingInputTable(clicksTableName, genericTableArgs);
 
@@ -79,6 +79,10 @@ const aggregateTableColumns = [
     {
         name: "count",
         type: "int"
+    },
+    {
+        name: "time",
+        type: "string"
     }
 ];
 
@@ -102,7 +106,7 @@ const aggregationFunction = async (event: EventRuleEvent) => {
     const impressionRows = await impressionsPromise;
     const clickCount = clickRows.records[0]['_col0'];
     const impressionsCount = impressionRows.records[0]['_col0'];
-    const data = `{ "event_type": "${clicksTableName}", "count": ${clickCount} }\n{ "event_type": "${impressionsTableName}", "count": ${impressionsCount} }`;
+    const data = `{ "event_type": "${clicksTableName}", "count": ${clickCount}, "time": "${partitionKey}" }\n{ "event_type": "${impressionsTableName}", "count": ${impressionsCount}, "time": "${partitionKey}"}`;
     const s3Client = new S3();
     await s3Client.putObject({
         Bucket: dwBucket.get(),

--- a/examples/datawarehouse/index.ts
+++ b/examples/datawarehouse/index.ts
@@ -1,5 +1,4 @@
 import * as pulumi from "@pulumi/pulumi";
-import * as aws from "@pulumi/aws";
 
 import { ServerlessDataWarehouse, StreamingInputTableArgs } from "../../lib/datawarehouse";
 import { createEventGenerator } from "./eventGenerator";

--- a/lib/datawarehouse/index.ts
+++ b/lib/datawarehouse/index.ts
@@ -5,6 +5,9 @@ import { getS3Location } from "../utils";
 import { InputStream, InputStreamArgs } from "./inputStream";
 import { HourlyPartitionRegistrar, PartitionRegistrarArgs } from "./partitionRegistrar";
 import { BucketArgs } from "@pulumi/aws/s3";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
+import { ARN } from "@pulumi/aws";
+import { LambdaCronJob, LambdaCronJobArgs } from "./lambdaCron";
 
 export class ServerlessDataWarehouse extends pulumi.ComponentResource {
 
@@ -18,14 +21,13 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
      * TODO: 
      * let's expose some helpful utilities here:
      * GetAthenaQueryIAMPolicy: return the JSON required to query against this thing.
-     * * - support multiple tables - use convention to make this happen. 
      * Add option for encryption
      * 
      */
     constructor(name: string, args?: DataWarehouseArgs) {
         super("serverless:datawarehouse", name, {});
 
-        const bucketArgs: BucketArgs | undefined = args?.isDev ? { forceDestroy: true} : undefined;
+        const bucketArgs: BucketArgs | undefined = args?.isDev ? { forceDestroy: true } : undefined;
 
         const dataWarehouseBucket = new aws.s3.Bucket("datawarehouse-bucket", bucketArgs, { parent: this });
         const queryResultsBucket = new aws.s3.Bucket("query-results-bucket", bucketArgs, { parent: this });
@@ -47,7 +49,10 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
         if (this.tables[name]) {
             throw new Error(`Duplicate table! Name: ${name}`);
         }
-        const table = this.createTable(name, args.columns, args.partitionKeys);
+
+        const dataFormat = args.dataFormat ? args.dataFormat : "parquet";
+
+        const table = this.createTable(name, args.columns, dataFormat, args.partitionKeys);
         this.tables[name] = table;
 
         return this;
@@ -61,7 +66,7 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
             name: partitionKey,
             type: "string"
         }];
-        
+
         const tableArgs: TableArgs = {
             columns,
             partitionKeys,
@@ -75,8 +80,8 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
             databaseName: this.database.name,
             tableName: name
         };
-        
-        const { inputStream } = new InputStream(`inputstream-${name}`, streamArgs, { parent: this});
+
+        const { inputStream } = new InputStream(`inputstream-${name}`, streamArgs, { parent: this });
         this.inputStreams[name] = inputStream;
 
         const registrarArgs: PartitionRegistrarArgs = {
@@ -93,24 +98,43 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
         return this;
     }
 
-    public withBatchInputTable() { /* TODO */ }
+    public withBatchInputTable(name: string, args: BatchInputTableArgs): ServerlessDataWarehouse {
+        const { columns, partitionKeys, jobFn, scheduleExpression, policyARNsToAttach, dataFormat } = args;
+        const tableArgs: TableArgs = {
+            columns,
+            partitionKeys,
+            dataFormat,
+        };
+
+        this.withTable(name, tableArgs);
+
+        const lambdaCronArgs: LambdaCronJobArgs = {
+            jobFn,
+            scheduleExpression,
+            policyARNsToAttach
+        };
+
+        const lambdaCron = new LambdaCronJob(name, lambdaCronArgs, { parent: this });
+
+        return this;
+    }
 
     public getTable(name: string): aws.glue.CatalogTable {
-        const table = this.tables[name]; 
-        if(!table) {
+        const table = this.tables[name];
+        if (!table) {
             throw new Error(`Table '${name}' does not exist.`);
         }
 
         return table;
     }
-    
+
     public listTables(): string[] {
         return Object.keys(this.tables);
     }
 
     public getInputStream(tableName: string): aws.kinesis.Stream {
-        const stream = this.inputStreams[tableName]; 
-        if(!stream) {
+        const stream = this.inputStreams[tableName];
+        if (!stream) {
             throw new Error(`Input stream for table '${tableName}' does not exist.`);
         }
 
@@ -118,23 +142,38 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
     }
 
     // TODO: support formats other than parquet
-    private createTable(name: string, columns: input.glue.CatalogTableStorageDescriptorColumn[], partitionKeys?: input.glue.CatalogTablePartitionKey[]): aws.glue.CatalogTable {
+    private createTable(name: string, columns: input.glue.CatalogTableStorageDescriptorColumn[], dataFormat: DataFormat, partitionKeys?: input.glue.CatalogTablePartitionKey[]): aws.glue.CatalogTable {
         const location = getS3Location(this.dataWarehouseBucket, name);
+
+        const parquetStorageDescriptor = {
+            location,
+            inputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
+            outputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
+            serDeInfo: {
+                parameters: { "serialization.format": "1" },
+                name: "ParquetHiveSerDe",
+                serializationLibrary: "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+            },
+            columns
+        };
+
+        const jsonStorageDescriptor = {
+            location,
+            inputFormat: "org.apache.hadoop.mapred.TextInputFormat",
+            outputFormat: "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+            serDeInfo: {
+                name: "OpenXJSONSerDe",
+                serializationLibrary: "org.openx.data.jsonserde.JsonSerDe"
+            },
+            columns
+        };
+
+        const storageDescriptor = dataFormat === "JSON" ? jsonStorageDescriptor : parquetStorageDescriptor;
         return new aws.glue.CatalogTable(name, {
             name: name,
             databaseName: this.database.name,
             tableType: "EXTERNAL_TABLE",
-            storageDescriptor: {
-                location,
-                inputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat",
-                outputFormat: "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat",
-                serDeInfo: {
-                    parameters: { "serialization.format": "1" },
-                    name: "ParquetHiveSerDe",
-                    serializationLibrary: "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
-                },
-                columns
-            },
+            storageDescriptor,
             partitionKeys,
         }, { parent: this });
     }
@@ -146,9 +185,12 @@ export interface DataWarehouseArgs {
     isDev?: boolean;
 }
 
+export type DataFormat = "JSON" | "parquet";
+
 export interface TableArgs {
     columns: input.glue.CatalogTableStorageDescriptorColumn[];
     partitionKeys?: input.glue.CatalogTablePartitionKey[];
+    dataFormat?: DataFormat;
 }
 
 export interface StreamingInputTableArgs {
@@ -157,4 +199,13 @@ export interface StreamingInputTableArgs {
     region: string;
     partitionKeyName?: string;
     scheduleExpression?: string; // TODO: we should remove this. It's useful in active development, but users would probably never bother. 
+}
+
+export interface BatchInputTableArgs {
+    columns: input.glue.CatalogTableStorageDescriptorColumn[];
+    partitionKeys?: input.glue.CatalogTablePartitionKey[];
+    jobFn: (event: EventRuleEvent) => any;
+    scheduleExpression: string;
+    policyARNsToAttach?: pulumi.Input<ARN>[];
+    dataFormat?: DataFormat;
 }

--- a/lib/datawarehouse/index.ts
+++ b/lib/datawarehouse/index.ts
@@ -50,7 +50,7 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
             throw new Error(`Duplicate table! Name: ${name}`);
         }
 
-        const dataFormat = args.dataFormat ? args.dataFormat : "parquet";
+        let dataFormat = this.validateFormatAndGetDefault(args.dataFormat);
 
         const table = this.createTable(name, args.columns, dataFormat, args.partitionKeys);
         this.tables[name] = table;
@@ -139,6 +139,25 @@ export class ServerlessDataWarehouse extends pulumi.ComponentResource {
         }
 
         return stream;
+    }
+
+    private validateFormatAndGetDefault(dataFormat: DataFormat | undefined) {
+        let format = dataFormat;
+        const defaultFormat: DataFormat = "parquet";
+
+        switch (format) {
+            case "parquet":
+                break;
+            case "JSON":
+                break;
+            case undefined:
+                format = defaultFormat;
+                break;
+            default:
+                throw new Error(`dataFormat must be one of 'JSON' or 'parquet'. Encountered unknown value: ${dataFormat}`);
+        }
+
+        return format;
     }
 
     // TODO: support formats other than parquet

--- a/lib/datawarehouse/lambdaCron/index.ts
+++ b/lib/datawarehouse/lambdaCron/index.ts
@@ -39,6 +39,12 @@ export class LambdaCronJob extends pulumi.ComponentResource {
             }
         }
 
+        // always attach the lambda policy for logging, etc. 
+        new aws.iam.RolePolicyAttachment(`${name}-Attachment-lambda`, {
+            role: partitionRole,
+            policyArn: aws.iam.ManagedPolicies.AWSLambdaFullAccess,
+        }, options);
+
         const cron = new aws.cloudwatch.EventRule(`${name}-cron`, {
             scheduleExpression
         }, options);
@@ -46,6 +52,7 @@ export class LambdaCronJob extends pulumi.ComponentResource {
         cron.onEvent(`${name}-cronJob`, new CallbackFunction(`${name}-callback`, {
             role: partitionRole,
             callback: jobFn,
+            timeout: 900
         }), options);
     }
 }

--- a/lib/datawarehouse/lambdaCron/index.ts
+++ b/lib/datawarehouse/lambdaCron/index.ts
@@ -1,0 +1,57 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+import { CallbackFunction } from "@pulumi/aws/lambda";
+import { EventRuleEvent } from "@pulumi/aws/cloudwatch";
+import { getS3Location } from "../../utils";
+import { ARN } from "@pulumi/aws";
+
+export class LambdaCronJob extends pulumi.ComponentResource {
+
+    constructor(name: string, args: LambdaCronJobArgs, opts?: pulumi.ComponentResourceOptions) { 
+        super("serverless:lambdacronjob", name, opts);
+        const options  = { parent: this }; 
+        const { scheduleExpression, jobFn, policyARNsToAttach } = args;
+
+        let lambdaAssumeRolePolicy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Action": "sts:AssumeRole",
+                    "Principal": {
+                        "Service": "lambda.amazonaws.com",
+                    },
+                    "Effect": "Allow",
+                    "Sid": "",
+                },
+            ],
+        };
+
+        const partitionRole = new aws.iam.Role(`${name}-Role`, {
+            assumeRolePolicy: JSON.stringify(lambdaAssumeRolePolicy)
+        }, options);
+
+        if(policyARNsToAttach) {
+            for(let i = 0; i < policyARNsToAttach.length; i++) {
+                new aws.iam.RolePolicyAttachment(`${name}-Attachment-${i}`, {
+                    role: partitionRole,
+                    policyArn: policyARNsToAttach[i],
+                }, options);
+            }
+        }
+
+        const cron = new aws.cloudwatch.EventRule(`${name}-cron`, {
+            scheduleExpression
+        }, options);
+
+        cron.onEvent(`${name}-cronJob`, new CallbackFunction(`${name}-callback`, {
+            role: partitionRole,
+            callback: jobFn,
+        }), options);
+    }
+}
+
+export interface LambdaCronJobArgs {
+   jobFn: (event: EventRuleEvent) => any;
+    scheduleExpression: string;
+    policyARNsToAttach?: pulumi.Input<ARN>[];
+}

--- a/lib/datawarehouse/partitionRegistrar/index.ts
+++ b/lib/datawarehouse/partitionRegistrar/index.ts
@@ -19,7 +19,6 @@ export class HourlyPartitionRegistrar extends pulumi.ComponentResource {
 
         const policyARNsToAttach = [
             aws.iam.ManagedPolicies.AmazonAthenaFullAccess,
-            aws.iam.ManagedPolicies.AWSLambdaFullAccess
         ];
 
 


### PR DESCRIPTION
Add a prototype for .withBatchInputTable that uses lambda. Dues to lambda's various limits (disk, memory, 15m max timeout), we should support docker here but this is a good proof of concept and low friction for getting started. 

In addition I added a `DataFormat` option that enables configuring the glue table to read JSON records, it still uses parquet by default. 